### PR TITLE
Removed multiple replaces in favour of a single replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,25 +2,31 @@
  * node-s3-url-encode - Because s3 urls are annoying
  */
 
+var encodings = {
+  '\+': "%2B",
+  '\!': "%21",
+  '\"': "%22",
+  '\#': "%23",
+  '\$': "%24",
+  '\&': "%26",
+  '\'': "%27",
+  '\(': "%28",
+  '\)': "%29",
+  '\*': "%2A",
+  '\,': "%2C",
+  '\:': "%3A",
+  '\;': "%3B",
+  '\=': "%3D",
+  '\?': "%3F",
+  '\@': "%40",
+};
+
 function encodeS3URI(filename) {
   return encodeURI(filename) // Do the standard url encoding
-              .replace(/\+/img, "%2B")
-              .replace(/\!/img, "%21")
-              .replace(/\"/img, "%22")
-              .replace(/\#/img, "%23")
-              .replace(/\$/img, "%24")
-              .replace(/\&/img, "%26")
-              .replace(/\'/img, "%27")
-              .replace(/\(/img, "%28")
-              .replace(/\)/img, "%29")
-              .replace(/\*/img, "%2A")
-              .replace(/\+/img, "%2B")
-              .replace(/\,/img, "%2C")
-              .replace(/\:/img, "%3A")
-              .replace(/\;/img, "%3B")
-              .replace(/\=/img, "%3D")
-              .replace(/\?/img, "%3F")
-              .replace(/\@/img, "%40");
+              .replace(
+                  /(\+|!|"|#|\$|&|'|\(|\)|\*|\+|,|:|;|=|\?|@)/img,
+                  function(match) { return encodings[match]; }
+              );
 
 }
 


### PR DESCRIPTION
Replaces the multiple replaces for a single one that uses a function for matching. Avoids the 16 iterations of the input in favour of one with a slightly more complex regex.